### PR TITLE
Ajout d'un Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,21 @@
+FROM node:alpine3.22
+# Need to be run with --tty docker run option
+
+RUN addgroup -S gitgraph ; adduser -D -h /app -G gitgraph gitgraph 
+
+COPY --chown=gitgraph:gitgraph . /app
+
+USER gitgraph
+WORKDIR /app
+
+RUN yarn
+
+ENV NODE_OPTIONS=--openssl-legacy-provider
+ENV NODE_VERSION=25.6.0
+ENV SHLVL=1
+ENV HOME=/app
+ENV PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin
+
+EXPOSE 3000
+
+CMD ["yarn","start"]

--- a/MES_NOTES.md
+++ b/MES_NOTES.md
@@ -1,0 +1,30 @@
+# Mes notes
+
+## Incus / Lxc
+
+```shell
+code
+NODE_OPTIONS=--openssl-legacy-provider
+incus launch images:alpine/edge gitgraph
+incus shell gitgraph
+        gitgraph:~# apk add nodejs yarn
+        gitgraph:~# apk add openssl
+        gitgraph:~# mkdir gitgraph
+        gitgraph:~# echo "export NODE_OPTIONS=--openssl-legacy-provider" >> .profile
+incus file push ./ gitgraph/root/gitgraph -rp
+incus exec gitgraph --cwd /root/gitgraph --env NODE_OPTIONS=--openssl-legacy-provider -- yarn start
+```
+
+## Docker
+
+cf [Dockerfile](./Dockerfile)
+
+```shell
+docker build -t djayroma/testgitgraph:alpine3.22 .
+docker run --tty --port 3000:3000 djayroma/testgitgraph:alpine3.22
+# Important le --tty
+
+$ docker run -dt -p 3000:3000 djayroma/testgitgraph:alpine3.22 
+d83622bb2d1454238d31f3619ca7f4f810977d011bffa392c0f98924e4a77604
+# Le -d pour l'arrière plan
+```


### PR DESCRIPTION
Ajout d'un Dockerfile

ATTENTION : l'image ne peut pas être lancé sans l'option `-t/--tty`

- Utilisateur `gitgraph`
- Exposition du port 3000
- Ajout de l'option `NODE_OPTIONS=--openssl-legacy-provider`